### PR TITLE
fix CMake Error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(fcitx-table-other VERSION 5.0.5 LANGUAGES NONE)
+project(fcitx-table-other VERSION 5.0.5)
 
 find_package(ECM 1.0 REQUIRED)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})


### PR DESCRIPTION
Hi maintainer.
libimetable-dev is installed,but cmake still has the following error,
Make Error at CMakeLists.txt:12 (find_package):
  By not providing "FindLibIMETable.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "LibIMETable", but CMake did not find one.

  Could not find a package configuration file provided by "LibIMETable" with
  any of the following names:

    LibIMETableConfig.cmake
    libimetable-config.cmake

  Add the installation prefix of "LibIMETable" to CMAKE_PREFIX_PATH or set
  "LibIMETable_DIR" to a directory containing one of the above files.  If
  "LibIMETable" provides a separate development package or SDK, be sure it
  has been installed.
 